### PR TITLE
handle deletion of PhpThrownExceptionsAnalyzer#getExceptionClasses

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -43,7 +43,7 @@
   ]]>
     </change-notes>
 
-    <idea-version since-build="171.3780"/>
+    <idea-version since-build="173.2290"/>
 
     <depends>com.jetbrains.php</depends>
     <depends>com.intellij.modules.platform</depends>

--- a/src/de/espend/idea/php/phpunit/intention/MethodExceptionIntentionAction.java
+++ b/src/de/espend/idea/php/phpunit/intention/MethodExceptionIntentionAction.java
@@ -8,26 +8,25 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiRecursiveElementVisitor;
-import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.ui.components.JBList;
 import com.intellij.util.IncorrectOperationException;
 import com.jetbrains.php.codeInsight.PhpScopeHolder;
-import com.jetbrains.php.lang.formatter.PhpCodeStyleSettings;
 import com.jetbrains.php.lang.inspections.PhpThrownExceptionsAnalyzer;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
-import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.phpunit.PhpUnitUtil;
-import de.espend.idea.php.phpunit.utils.PhpElementsUtil;
 import de.espend.idea.php.phpunit.utils.PhpUnitPluginUtil;
+import one.util.streamex.StreamEx;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
-import java.util.function.Predicate;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -105,33 +104,13 @@ public class MethodExceptionIntentionAction extends PsiElementBaseIntentionActio
             }
         });
 
-        Collection<PhpType> phpTypes = new ArrayList<>();
-
-        PhpCodeStyleSettings phpCodeStyleSettings = CodeStyleSettingsManager
-            .getSettings(psiElement.getProject())
-            .getCustomSettings(PhpCodeStyleSettings.class);
-
-        int depth = phpCodeStyleSettings.PHPDOC_THROWS_CALL_TREE_ANALYSIS_DEPTH;
-
-        for (MethodReference methodReference : methodReferences) {
-            PsiElement resolve = methodReference.resolve();
-            if(resolve instanceof PhpScopeHolder) {
-                PhpType[] exceptionClasses = PhpThrownExceptionsAnalyzer.getExceptionClasses(
-                    (PhpScopeHolder) resolve,
-                    psiElement.getProject(),
-                    depth,
-                    false,
-                    false
-                );
-
-                phpTypes.addAll(Arrays.asList(exceptionClasses));
-            }
-        }
-
-        return phpTypes.stream()
-            .map(phpType -> StringUtils.stripStart(phpType.toString(), "\\"))
-            .filter(s -> !s.toLowerCase().contains("phpunit"))
-            .sorted()
-            .collect(Collectors.toCollection(HashSet::new));
+        return StreamEx.of(methodReferences)
+                .map(PsiReference::resolve)
+                .select(PhpScopeHolder.class)
+                .flatCollection(PhpThrownExceptionsAnalyzer::getExceptionClasses)
+                .map(phpType -> StringUtils.stripStart(phpType.toString(), "\\"))
+                .filter(s -> !s.toLowerCase().contains("phpunit"))
+                .sorted()
+                .collect(Collectors.toCollection(HashSet::new));
     }
 }


### PR DESCRIPTION
One of the overrides of the mentioned method was removed in 2017.3. The commit is intended to replace its usage.